### PR TITLE
update to reflect 3.1.1 has been ratified by OASIS

### DIFF
--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -18,11 +18,7 @@ IBM contributes to the development and support of many of these libraries.
 .. _Eclipse Paho project: http://eclipse.org/paho/
 
 MQTT 3.1 is the version of the protocol that is in widest use
-today. Version 3.1.1 contains a number of minor enhancements, and is
-currently a Candidate OASIS Standard (ratification by the OASIS
-standards development organization is expected later this year). The IBM
-Internet of Things Foundation offers informal support for version 3.1.1
-now, with formal support to follow ratification.
+today. Version 3.1.1 contains a number of minor enhancements, and has been ratified as an OASIS Standard. 
 
 One reason for using version 3.1.1 is that the maximum length of the
 MQTT Client Identifier (ClientId) is increased from the 23 character


### PR DESCRIPTION
Version 3.1.1 has been ratified by OASIS, so this needs to be updated accordingly. 
see link: 
https://www.oasis-open.org/news/announcements/mqtt-version-3-1-1-becomes-an-oasis-standard