### PR TITLE
Update python_cli_for_apps.rst

### DIFF
--- a/docs/libraries/python_cli_for_apps.rst
+++ b/docs/libraries/python_cli_for_apps.rst
@@ -126,7 +126,7 @@ instance of the Event class:
 
     ...
     client.connect()
-    client.eventCallback = myEventCallback
+    client.deviceEventCallback = myEventCallback
     client.subscribeToDeviceEvents()
 
 
@@ -207,7 +207,7 @@ The following properties are only set when the action is "Disconnect":
 
     ...
     client.connect()
-    client.statusCallback = myStatusCallback
+    client.deviceStatusCallback = myStatusCallback
     client.subscribeToDeviceStstus()
 
 


### PR DESCRIPTION
Maybe because of the latest versions of ibmiotf, but the callback functions seems to be renamed from what described in the original tutorial.  As it would not show any error messages but ignore any event/command/status if we use the obsolete callback function names in our code, it is posing critically bad impressions on the library or even on the backend.  We may need to care about describing which versions of ibmiotf we are talking about in the tutorial.