### PR TITLE
Update mqtt.rst to clarify recommended ciphers (RTC 93394)

### DIFF
--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The Foundation supports encrypted MQTT connections on port 8883 or port 443 for WebSockets. *We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
+.. note:: The Foundation supports encrypted MQTT connections on port 8883 or port 443 for WebSockets. IoT Foundation requires TLS v1.2. *We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256 *(as of Jun 1 2015)* .
+.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256 *(as of Jun 1 2015)*.
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256.
+.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256 *as of Jun 1 2015* .
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,10 +74,9 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The Foundation only supports **TLS v1.2 with AES 128 ciphers**. Please ensure your 
-    client library is able to meet these requirements.
-
-
+.. note:: The Foundation supports Encrypted MQTT connections on port 8883 or port 443 for WebSockets.
+   We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256
+   
 ----
 
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,8 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The Foundation supports Encrypted MQTT connections on port 8883 or port 443 for WebSockets.
-   We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256
+.. note:: The Foundation supports encrypted MQTT connections on port 8883 or port 443 for WebSockets. *We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256
+.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256.
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The Foundation supports encrypted MQTT connections on port 8883 or port 443 for WebSockets. IoT Foundation requires TLS v1.2. *We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
+.. note:: *The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256 *as of Jun 1 2015* .
+.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256 *(as of Jun 1 2015)* .
    
 ----
 

--- a/docs/messaging/mqtt.rst
+++ b/docs/messaging/mqtt.rst
@@ -74,7 +74,7 @@ in pem format.  The following file contains the entire certificate chain for
     domains, in which case, if you can not change libraries, you will need to turn 
     off certificate checking.
 
-.. note:: *The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256*
+.. note:: The IoT Foundation requires TLS v1.2. We suggest the following cipher suites: ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256 or AES128-GCM-SHA256
    
 ----
 


### PR DESCRIPTION
The statement before implied that only 128 bit ciphers are supported. That is not correct and was causing confusion. Updates show some recommended ciphers and do not rule out other possibilities. Documenting a full list deemed to brutal to include here.