### PR TITLE
mistype in config format & describe clearly about format

### DIFF
--- a/docs/libraries/python_cli_for_devices.rst
+++ b/docs/libraries/python_cli_for_devices.rst
@@ -61,7 +61,7 @@ The content of the configuration file must be in the following format(need not c
     org=$orgId
     type=$myDeviceType
     id=$myDeviceId
-    auth-method=$token
+    auth-method=token
     auth-token=$token
 
 

--- a/docs/libraries/python_cli_for_devices.rst
+++ b/docs/libraries/python_cli_for_devices.rst
@@ -53,15 +53,15 @@ Instead of including an options dict directly, you can use a configuration file 
     except ibmiotf.ConnectionException  as e:
       ...
 
-The content of the configuration file must be in the following format:
+The content of the configuration file must be in the following format(need not contain **$** sign):
 
 ::
 
     [device]
     org=$orgId
-    typ=$myDeviceType
+    type=$myDeviceType
     id=$myDeviceId
-    auth-method=token
+    auth-method=$token
     auth-token=$token
 
 


### PR DESCRIPTION
`typ=$myDeviceType`
change to 
`type=$myDeviceType`

and describe clearly about format
format need not contain **$** sign