### PR TITLE
Remove statement that states all fields are optional (update location)

### DIFF
--- a/docs/device_mgmt/operations/update.rst
+++ b/docs/device_mgmt/operations/update.rst
@@ -19,7 +19,7 @@ Topic
 Message Format
 ~~~~~~~~~~~~~~~
 
-All fields for this operation are optional. The "measuredDateTime" is the date of location measurement. The "updatedDateTime" is the date of the update to the device information. For efficiency reasons, IoTF may batch updates to location information so the updates may be slightly delayed. The "latitude" and "longitude" should be specified in decimal degrees using WGS84. 
+The "measuredDateTime" is the date of location measurement. The "updatedDateTime" is the date of the update to the device information. For efficiency reasons, IoTF may batch updates to location information so the updates may be slightly delayed. The "latitude" and "longitude" should be specified in decimal degrees using WGS84. 
 
 Whenever location is updated, the values provided for latitude, longitude, elevation and uncertainty are considered as a single multi-value update. The latitude and longitude are mandatory and must both provided with each update, while the elevation and uncertainty are optional and can be omitted. If an optional value is provided on an update and then omitted on a later update, the earlier value is deleted by the later update. Each update is considered as a complete multi-value set.
 


### PR DESCRIPTION
Latitude and longitude are required for updating a device's location, it is mentioned in a later paragraph.